### PR TITLE
feat: Agregué PK id en tablas inscriptions y groupassignments

### DIFF
--- a/database/migrations/2022_05_03_041706_create_inscriptions_table.php
+++ b/database/migrations/2022_05_03_041706_create_inscriptions_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('inscriptions', function (Blueprint $table) {
+            $table->id();
             $table->double('calificacion');
             $table->string('estatus');
             $table->boolean('asistencias_minimas');

--- a/database/migrations/2022_05_03_041917_create_groupassignments_table.php
+++ b/database/migrations/2022_05_03_041917_create_groupassignments_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::create('groupassignments', function (Blueprint $table) {
+            $table->id();
             $table->time('hora_inicio');
             $table->time('hora_fin');
             $table->foreignId('group_id')


### PR DESCRIPTION
Resulta que como en nuestro modelo E-R la tabla inscripcions y groupsassigments tienen una PK compuesta por dos foraneas pues por guiarme de ahí, en las migraciones solo  dichas tablas les dejé sus foraneas ninguna PK, pero ayer cuando me dispuse a hacer mi vista ASIGNAR CALIFICACIONES, noté la necesidad de un id, me documenté un poco, y se menciona que 
en la [documentación oficial](https://laravel.com/docs/7.x/eloquent#eloquent-model-conventions), Laravel espera que:

- Los modelos tengan solo una llave primaria
- Que la llave primaria tenga el nombre de id

Segunda página que me lo aclaró y tiene sentido, y razón.
[página](https://es.stackoverflow.com/questions/339818/llave-primaria-compuesta-en-laravel)